### PR TITLE
feat : 상담원 회원가입, 로그인, 상담 완료 구현 및 Etag와 로컬 캐시 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,10 @@ dependencies {
 	// Aho-corasick algorithm
 	implementation 'org.ahocorasick:ahocorasick:0.6.3'
 
+	// caffeine 캐시
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'com.github.ben-manes.caffeine:caffeine'
+
 }
 ext {
 	set('springCloudVersion', "2022.0.3")

--- a/src/docs/asciidoc/members.adoc
+++ b/src/docs/asciidoc/members.adoc
@@ -86,3 +86,46 @@ include::{snippets}/match-consultant/http-request.adoc[]
 
 include::{snippets}/match-consultant/http-response.adoc[]
 include::{snippets}/match-consultant/response-fields.adoc[]
+
+
+== 상담원 상담 가능 상태로 바꿔주는 API
+상담이 끝나면 상담원의 상담 가능 상태를
+UNAVAILABLE에서 AVAILABLE로 바꿔줍니다.
+
+=== Request
+
+include::{snippets}/end-consultation-and-change-available/http-request.adoc[]
+include::{snippets}/end-consultation-and-change-available/path-parameters.adoc[]
+
+=== Response (Success)
+
+include::{snippets}/end-consultation-and-change-available/http-response.adoc[]
+
+==  상담원 회원가입 API
+
+상담원 회원가입 API
+사원 번호는 미리 받은 상태입니다.
+
+=== Request
+
+include::{snippets}/sign-up-consultant/http-request.adoc[]
+include::{snippets}/sign-up-consultant/request-fields.adoc[]
+
+=== Response (Success)
+
+include::{snippets}/sign-up-consultant/http-response.adoc[]
+include::{snippets}/sign-up-consultant/response-fields.adoc[]
+
+==  상담원 로그인 API
+
+상담원 로그인 API
+
+=== Request
+
+include::{snippets}/login-consultant/http-request.adoc[]
+include::{snippets}/login-consultant/request-fields.adoc[]
+
+=== Response (Success)
+
+include::{snippets}/login-consultant/http-response.adoc[]
+include::{snippets}/login-consultant/response-fields.adoc[]

--- a/src/main/java/com/hellomeritz/chat/controller/BanWordController.java
+++ b/src/main/java/com/hellomeritz/chat/controller/BanWordController.java
@@ -1,0 +1,26 @@
+package com.hellomeritz.chat.controller;
+
+import com.hellomeritz.chat.service.BanWordService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/banwords")
+public class BanWordController {
+
+    private final BanWordService banWordService;
+
+    public BanWordController(BanWordService banWordService) {
+        this.banWordService = banWordService;
+    }
+
+    @PatchMapping
+    public ResponseEntity<Void> uploadBanWord( ) {
+        banWordService.uploadBanWordsToMemory();
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .build();
+    }
+
+}

--- a/src/main/java/com/hellomeritz/chat/controller/dto/request/ChatRoomPasswordCreateRequest.java
+++ b/src/main/java/com/hellomeritz/chat/controller/dto/request/ChatRoomPasswordCreateRequest.java
@@ -1,12 +1,8 @@
 package com.hellomeritz.chat.controller.dto.request;
 
-import com.hellomeritz.chat.domain.ChatRoomPassword;
-import com.hellomeritz.chat.service.dto.param.ChatRoomCreateParam;
+import com.hellomeritz.global.encryption.PassWord;
 import com.hellomeritz.chat.service.dto.param.ChatRoomPasswordCreateParam;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
-import org.springframework.web.bind.annotation.PathVariable;
 
 import java.time.LocalDateTime;
 
@@ -17,7 +13,7 @@ public record ChatRoomPasswordCreateRequest(
 
     public ChatRoomPasswordCreateParam toChatRoomPasswordCreateParam(Long chatRoomId) {
         return new ChatRoomPasswordCreateParam(
-                ChatRoomPassword.of(chatRoomPassword),
+                PassWord.of(chatRoomPassword),
                 chatRoomId,
                 LocalDateTime.now()
         );

--- a/src/main/java/com/hellomeritz/chat/service/ChatService.java
+++ b/src/main/java/com/hellomeritz/chat/service/ChatService.java
@@ -1,18 +1,6 @@
 package com.hellomeritz.chat.service;
 
-import com.hellomeritz.chat.domain.ChatMessage;
 import com.hellomeritz.chat.domain.ChatRoom;
-import com.hellomeritz.chat.global.stt.SttManager;
-import com.hellomeritz.chat.global.stt.SttManagerHandler;
-import com.hellomeritz.chat.global.stt.SttProvider;
-import com.hellomeritz.chat.global.stt.dto.SttResponse;
-import com.hellomeritz.chat.global.translator.TranslateProvider;
-import com.hellomeritz.chat.global.translator.TranslationResponse;
-import com.hellomeritz.chat.global.translator.Translator;
-import com.hellomeritz.chat.global.translator.TranslatorHandler;
-import com.hellomeritz.chat.global.uploader.AudioUploadResponse;
-import com.hellomeritz.chat.global.uploader.AudioUploader;
-import com.hellomeritz.chat.repository.chatentry.ChatRoomEntryLocalRepository;
 import com.hellomeritz.chat.repository.chatentry.ChatRoomEntryRepository;
 import com.hellomeritz.chat.repository.chatmessage.ChatMessageRepository;
 import com.hellomeritz.chat.repository.chatmessage.dto.ChatMessageGetRepositoryResponses;
@@ -26,13 +14,11 @@ import com.hellomeritz.chat.repository.chatsession.ChatSession;
 import com.hellomeritz.chat.repository.chatsession.ChatSessionRepository;
 import com.hellomeritz.chat.service.dto.param.*;
 import com.hellomeritz.chat.service.dto.result.*;
-import com.hellomeritz.global.CircuitBreakerBot;
 import com.hellomeritz.member.global.IpSensor;
-import com.hellomeritz.member.global.encryption.PasswordEncoder;
-import com.hellomeritz.member.global.encryption.dto.EncryptionResponse;
+import com.hellomeritz.global.encryption.PasswordEncoder;
+import com.hellomeritz.global.encryption.dto.EncryptionResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/hellomeritz/chat/service/dto/param/ChatRoomPasswordCheckParam.java
+++ b/src/main/java/com/hellomeritz/chat/service/dto/param/ChatRoomPasswordCheckParam.java
@@ -1,8 +1,8 @@
 package com.hellomeritz.chat.service.dto.param;
 
-import com.hellomeritz.chat.domain.ChatRoomPassword;
+import com.hellomeritz.global.encryption.PassWord;
 import com.hellomeritz.chat.repository.chatroom.dto.ChatRoomPasswordInfo;
-import com.hellomeritz.member.global.encryption.dto.PasswordMatchRequest;
+import com.hellomeritz.global.encryption.dto.PasswordMatchRequest;
 
 import java.time.LocalDateTime;
 
@@ -20,7 +20,7 @@ public record ChatRoomPasswordCheckParam(
 
     public ChatRoomPasswordCreateParam toChatRoomPasswordCreateRequest() {
         return new ChatRoomPasswordCreateParam(
-                ChatRoomPassword.of(chatRoomPassword),
+                PassWord.of(chatRoomPassword),
                 chatRoomId,
                 LocalDateTime.now()
         );

--- a/src/main/java/com/hellomeritz/chat/service/dto/param/ChatRoomPasswordCreateParam.java
+++ b/src/main/java/com/hellomeritz/chat/service/dto/param/ChatRoomPasswordCreateParam.java
@@ -1,18 +1,18 @@
 package com.hellomeritz.chat.service.dto.param;
 
-import com.hellomeritz.chat.domain.ChatRoomPassword;
-import com.hellomeritz.member.global.encryption.dto.EncryptionRequest;
+import com.hellomeritz.global.encryption.PassWord;
+import com.hellomeritz.global.encryption.dto.EncryptionRequest;
 
 import java.time.LocalDateTime;
 
 public record ChatRoomPasswordCreateParam(
-        ChatRoomPassword chatRoomPassWord,
+        PassWord chatRoomPassWord,
         long chatRoomId,
         LocalDateTime enterChatRoomDateTime
 ) {
     public EncryptionRequest toEncryptionRequest(String ipAddress) {
         return new EncryptionRequest(
-                chatRoomPassWord.getChatRoomPassword(),
+                chatRoomPassWord.getPassword(),
                 ipAddress,
                 enterChatRoomDateTime
         );

--- a/src/main/java/com/hellomeritz/global/WebConfig.java
+++ b/src/main/java/com/hellomeritz/global/WebConfig.java
@@ -2,8 +2,14 @@ package com.hellomeritz.global;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hellomeritz.member.global.IpSensor;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.CacheControl;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
+import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
@@ -23,15 +29,38 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOriginPatterns("*")
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
-                .maxAge(3600);
+            .allowedOriginPatterns("*")
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
+            .maxAge(3600);
     }
 
     @Override
-    public void addInterceptors(InterceptorRegistry registry){
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/static/**")
+            .addResourceLocations("classpath:/static/")
+            .setCacheControl(CacheControl.maxAge(10, TimeUnit.SECONDS).mustRevalidate());
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new IpSensor(objectMapper))
-                .addPathPatterns("/users/*");
+            .addPathPatterns("/users/*");
+        registry.addInterceptor(new HandlerInterceptor() {
+            @Override
+            @PostConstruct
+            public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+                throws Exception {
+                if (request.getMethod().equals("GET")) {
+                    response.setHeader("Cache-Control", "no-cache");
+                }
+                return HandlerInterceptor.super.preHandle(request, response, handler);
+            }
+        });
+    }
+
+    @Bean
+    public ShallowEtagHeaderFilter shallowEtagHeaderFilter() {
+        return new ShallowEtagHeaderFilter();
     }
 
 }

--- a/src/main/java/com/hellomeritz/global/cache/CacheConfig.java
+++ b/src/main/java/com/hellomeritz/global/cache/CacheConfig.java
@@ -1,0 +1,35 @@
+package com.hellomeritz.global.cache;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public List<CaffeineCache> caffeineCaches() {
+        return Arrays.stream(CacheType.values())
+            .map(cache -> new CaffeineCache(cache.getCacheName(), Caffeine.newBuilder().recordStats()
+                .expireAfterWrite(cache.getExpiredHourAfterWrite(), TimeUnit.HOURS)
+                .maximumSize(cache.getMaximumSize())
+                .build()))
+            .toList();
+    }
+    @Bean
+    public CacheManager cacheManager(List<CaffeineCache> caffeineCaches) {
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+        cacheManager.setCaches(caffeineCaches);
+
+        return cacheManager;
+    }
+}

--- a/src/main/java/com/hellomeritz/global/cache/CacheType.java
+++ b/src/main/java/com/hellomeritz/global/cache/CacheType.java
@@ -1,0 +1,19 @@
+package com.hellomeritz.global.cache;
+
+import lombok.Getter;
+
+@Getter
+public enum CacheType {
+    FOREIGNER_PROFILE("foreigner", 1, 10000),
+    CONSULTANT_PROFILE("consultant", 3, 1000);
+
+    private final String cacheName;
+    private final int expiredHourAfterWrite;
+    private final int maximumSize;
+
+    CacheType(String cacheName, int expiredHourAfterWrite, int maximumSize) {
+        this.cacheName = cacheName;
+        this.expiredHourAfterWrite = expiredHourAfterWrite;
+        this.maximumSize = maximumSize;
+    }
+}

--- a/src/main/java/com/hellomeritz/global/encryption/PassWord.java
+++ b/src/main/java/com/hellomeritz/global/encryption/PassWord.java
@@ -1,47 +1,47 @@
-package com.hellomeritz.chat.domain;
+package com.hellomeritz.global.encryption;
 
 import lombok.Getter;
 import org.springframework.util.Assert;
 
 @Getter
-public class ChatRoomPassword {
+public class PassWord {
 
     private static final int MIN_PASSWORD_LENGTH = 10;
-    private String chatRoomPassword;
+    private String password;
 
-    private ChatRoomPassword() {
+    private PassWord() {
     }
 
-    private ChatRoomPassword(
-            String chatRoomPassword
+    private PassWord(
+            String password
     ) {
-        this.chatRoomPassword = chatRoomPassword;
+        this.password = password;
     }
 
-    public static ChatRoomPassword of(
-            String chatRoomPassword
+    public static PassWord of(
+            String password
     ) {
-        Assert.hasLength(chatRoomPassword, "비밀번호는 빈값이나 null 일 수 없습니다.");
-        checkLength(chatRoomPassword);
-        isContainEngAndSpecialCharAndDigit(chatRoomPassword);
+        Assert.hasLength(password, "비밀번호는 빈값이나 null 일 수 없습니다.");
+        checkLength(password);
+        isContainEngAndSpecialCharAndDigit(password);
 
-        return new ChatRoomPassword(chatRoomPassword);
+        return new PassWord(password);
     }
 
-    private static void checkLength(String chatRoomPassword) {
-        int passwordLength = chatRoomPassword.length();
+    private static void checkLength(String password) {
+        int passwordLength = password.length();
         if (passwordLength < MIN_PASSWORD_LENGTH) {
             throw new IllegalArgumentException(String.format("password의 자릿수가 %d를 넘지 않습니다. " +
                     "현재 자릿수는 %d 입니다.", MIN_PASSWORD_LENGTH, passwordLength));
         }
     }
 
-    private static void isContainEngAndSpecialCharAndDigit(String chatRoomPassword) {
+    private static void isContainEngAndSpecialCharAndDigit(String password) {
         boolean hasEnglish = false;
         boolean hasSpecialCharacter = false;
         boolean hasDigit = false;
 
-        for (char ch : chatRoomPassword.toCharArray()) {
+        for (char ch : password.toCharArray()) {
             if (Character.isLetter(ch)) {
                 hasEnglish = true;
             } else if (Character.isDigit(ch)) {

--- a/src/main/java/com/hellomeritz/global/encryption/PasswordEncoder.java
+++ b/src/main/java/com/hellomeritz/global/encryption/PasswordEncoder.java
@@ -1,10 +1,9 @@
-package com.hellomeritz.member.global.encryption;
+package com.hellomeritz.global.encryption;
 
-import com.hellomeritz.member.global.encryption.dto.EncryptionRequest;
-import com.hellomeritz.member.global.encryption.dto.EncryptionResponse;
-import com.hellomeritz.member.global.encryption.dto.PasswordMatchRequest;
-import com.hellomeritz.member.global.encryption.dto.SaltRequest;
-import org.springframework.beans.factory.annotation.Value;
+import com.hellomeritz.global.encryption.dto.EncryptionResponse;
+import com.hellomeritz.global.encryption.dto.SaltRequest;
+import com.hellomeritz.global.encryption.dto.EncryptionRequest;
+import com.hellomeritz.global.encryption.dto.PasswordMatchRequest;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKeyFactory;

--- a/src/main/java/com/hellomeritz/global/encryption/dto/EncryptionRequest.java
+++ b/src/main/java/com/hellomeritz/global/encryption/dto/EncryptionRequest.java
@@ -1,4 +1,4 @@
-package com.hellomeritz.member.global.encryption.dto;
+package com.hellomeritz.global.encryption.dto;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/hellomeritz/global/encryption/dto/EncryptionResponse.java
+++ b/src/main/java/com/hellomeritz/global/encryption/dto/EncryptionResponse.java
@@ -1,4 +1,4 @@
-package com.hellomeritz.member.global.encryption.dto;
+package com.hellomeritz.global.encryption.dto;
 
 public record EncryptionResponse(
         String password,

--- a/src/main/java/com/hellomeritz/global/encryption/dto/PasswordMatchRequest.java
+++ b/src/main/java/com/hellomeritz/global/encryption/dto/PasswordMatchRequest.java
@@ -1,4 +1,4 @@
-package com.hellomeritz.member.global.encryption.dto;
+package com.hellomeritz.global.encryption.dto;
 
 public record PasswordMatchRequest(
         char[] inputPassword,

--- a/src/main/java/com/hellomeritz/global/encryption/dto/SaltRequest.java
+++ b/src/main/java/com/hellomeritz/global/encryption/dto/SaltRequest.java
@@ -1,4 +1,4 @@
-package com.hellomeritz.member.global.encryption.dto;
+package com.hellomeritz.global.encryption.dto;
 
 public record SaltRequest(
         String ipAddress,

--- a/src/main/java/com/hellomeritz/member/controller/ConsultantController.java
+++ b/src/main/java/com/hellomeritz/member/controller/ConsultantController.java
@@ -1,8 +1,15 @@
 package com.hellomeritz.member.controller;
 
+import com.hellomeritz.member.controller.dto.request.ConsultantLoginRequest;
+import com.hellomeritz.member.controller.dto.request.ConsultantSignUpRequest;
+import com.hellomeritz.member.controller.dto.response.ConsultantLoginResponse;
 import com.hellomeritz.member.controller.dto.response.ConsultantMatchResponse;
+import com.hellomeritz.member.controller.dto.response.ConsultantSignUpResponse;
 import com.hellomeritz.member.service.MemberService;
+import com.hellomeritz.member.service.dto.param.ConsultantLoginParam;
 import com.hellomeritz.member.service.dto.param.FinancialConsultantChangeStateParam;
+import com.hellomeritz.member.service.dto.result.ConsultantSignUpResult;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import org.springframework.http.HttpStatus;
@@ -23,7 +30,7 @@ public class ConsultantController {
     @PatchMapping(
         produces = MediaType.APPLICATION_JSON_VALUE
     )
-    public ResponseEntity<ConsultantMatchResponse> matchConsultant(){
+    public ResponseEntity<ConsultantMatchResponse> matchConsultant() {
         return ResponseEntity.status(HttpStatus.OK)
             .body(ConsultantMatchResponse.to(memberService.matchConsultant()));
     }
@@ -32,14 +39,40 @@ public class ConsultantController {
         path = "/{fcId}"
     )
     public ResponseEntity<Void> endConsultation(
-        @Positive (message = "fcId는 양수여야 합니다.")
-        @NotNull (message = "fcId는 null일 수 없습니다.")
+        @Positive(message = "fcId는 양수여야 합니다.")
+        @NotNull(message = "fcId는 null일 수 없습니다.")
         @PathVariable Long fcId
     ) {
         memberService.endConsultation(FinancialConsultantChangeStateParam.to(fcId));
 
         return ResponseEntity.status(HttpStatus.OK)
             .build();
+    }
+
+    @PostMapping(
+        consumes = MediaType.APPLICATION_JSON_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<ConsultantSignUpResponse> signUp(
+        @Valid @RequestBody ConsultantSignUpRequest request
+    ) {
+        ConsultantSignUpResult consultantSignUpResult = memberService.signUp(request.toConsultantSignUpParam());
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ConsultantSignUpResponse.to(consultantSignUpResult));
+    }
+
+    @PatchMapping(
+        path = "/passwords",
+        consumes = MediaType.APPLICATION_JSON_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<ConsultantLoginResponse> login(
+        @Valid @RequestBody ConsultantLoginRequest request
+    ) {
+
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ConsultantLoginResponse.to(memberService.login(request.toConsultantLoginParam())));
     }
 
 }

--- a/src/main/java/com/hellomeritz/member/controller/ConsultantController.java
+++ b/src/main/java/com/hellomeritz/member/controller/ConsultantController.java
@@ -2,12 +2,13 @@ package com.hellomeritz.member.controller;
 
 import com.hellomeritz.member.controller.dto.response.ConsultantMatchResponse;
 import com.hellomeritz.member.service.MemberService;
+import com.hellomeritz.member.service.dto.param.FinancialConsultantChangeStateParam;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/consultants")
 @RestController
@@ -25,6 +26,20 @@ public class ConsultantController {
     public ResponseEntity<ConsultantMatchResponse> matchConsultant(){
         return ResponseEntity.status(HttpStatus.OK)
             .body(ConsultantMatchResponse.to(memberService.matchConsultant()));
+    }
+
+    @PutMapping(
+        path = "/{fcId}"
+    )
+    public ResponseEntity<Void> endConsultation(
+        @Positive (message = "fcId는 양수여야 합니다.")
+        @NotNull (message = "fcId는 null일 수 없습니다.")
+        @PathVariable Long fcId
+    ) {
+        memberService.endConsultation(FinancialConsultantChangeStateParam.to(fcId));
+
+        return ResponseEntity.status(HttpStatus.OK)
+            .build();
     }
 
 }

--- a/src/main/java/com/hellomeritz/member/controller/dto/request/ConsultantLoginRequest.java
+++ b/src/main/java/com/hellomeritz/member/controller/dto/request/ConsultantLoginRequest.java
@@ -1,0 +1,20 @@
+package com.hellomeritz.member.controller.dto.request;
+
+import com.hellomeritz.member.service.dto.param.ConsultantLoginParam;
+import jakarta.validation.constraints.NotBlank;
+
+public record ConsultantLoginRequest(
+
+    @NotBlank(message = "consultantPassword는 null이거나 빈값일 수 없습니다.")
+    String consultantPassword,
+
+    @NotBlank(message = "employNumber인 사원번호는 null이거나 빈값일 수 없습니다.")
+    String employeeNumber
+) {
+    public ConsultantLoginParam toConsultantLoginParam() {
+        return new ConsultantLoginParam(
+            employeeNumber,
+            consultantPassword
+        );
+    }
+}

--- a/src/main/java/com/hellomeritz/member/controller/dto/request/ConsultantSignUpRequest.java
+++ b/src/main/java/com/hellomeritz/member/controller/dto/request/ConsultantSignUpRequest.java
@@ -1,0 +1,37 @@
+package com.hellomeritz.member.controller.dto.request;
+
+import com.hellomeritz.global.encryption.PassWord;
+import com.hellomeritz.member.service.dto.param.ConsultantSignUpParam;
+import jakarta.validation.constraints.NotBlank;
+
+public record ConsultantSignUpRequest(
+
+    @NotBlank(message = "employNumber인 사원번호는 null이거나 빈값일 수 없습니다.")
+    String employeeNumber,
+
+    @NotBlank(message = "consultantPassword는 null이거나 빈값일 수 없습니다.")
+    String consultantPassword,
+
+    @NotBlank(message = "phoneNumber는 null이거나 빈값일 수 없습니다.")
+    String phoneNumber,
+
+    @NotBlank(message = "name호는 null이거나 빈값일 수 없습니다.")
+    String name,
+
+    @NotBlank(message = "profileUrl는 null이거나 빈값일 수 없습니다.")
+    String profileUrl,
+
+    @NotBlank(message = "introduceMessage는 null이거나 빈값일 수 없습니다.")
+    String introduceMessage
+) {
+    public ConsultantSignUpParam toConsultantSignUpParam() {
+        return new ConsultantSignUpParam(
+            employeeNumber,
+            PassWord.of(consultantPassword),
+            phoneNumber,
+            name,
+            profileUrl,
+            introduceMessage
+        );
+    }
+}

--- a/src/main/java/com/hellomeritz/member/controller/dto/response/ConsultantLoginResponse.java
+++ b/src/main/java/com/hellomeritz/member/controller/dto/response/ConsultantLoginResponse.java
@@ -1,0 +1,16 @@
+package com.hellomeritz.member.controller.dto.response;
+
+import com.hellomeritz.member.service.dto.result.ConsultantLoginResult;
+
+public record ConsultantLoginResponse(
+    boolean isMyConsultant,
+    long fcId
+) {
+
+    public static ConsultantLoginResponse to(ConsultantLoginResult result) {
+        return new ConsultantLoginResponse(
+            result.isMyConsultant(),
+            result.fcId()
+        );
+    }
+}

--- a/src/main/java/com/hellomeritz/member/controller/dto/response/ConsultantSignUpResponse.java
+++ b/src/main/java/com/hellomeritz/member/controller/dto/response/ConsultantSignUpResponse.java
@@ -1,0 +1,11 @@
+package com.hellomeritz.member.controller.dto.response;
+
+import com.hellomeritz.member.service.dto.result.ConsultantSignUpResult;
+
+public record ConsultantSignUpResponse(
+    long fcId
+) {
+    public static ConsultantSignUpResponse to(ConsultantSignUpResult result) {
+        return new ConsultantSignUpResponse(result.fcId());
+    }
+}

--- a/src/main/java/com/hellomeritz/member/domain/FinancialConsultant.java
+++ b/src/main/java/com/hellomeritz/member/domain/FinancialConsultant.java
@@ -1,7 +1,9 @@
 package com.hellomeritz.member.domain;
 
+import com.hellomeritz.global.encryption.PassWord;
 import jakarta.persistence.*;
 import lombok.Getter;
+import org.springframework.util.Assert;
 
 @Table(name = "financial_consultant")
 @Getter
@@ -28,6 +30,15 @@ public class FinancialConsultant {
     @Column(name = "consultation_state")
     private String consultationState;
 
+    @Column(name = "consultant_password")
+    private String consultantPassword;
+
+    @Column(name = "salt")
+    private String salt;
+
+    @Column(name = "employee_number")
+    private String employeeNumber;
+
     protected FinancialConsultant() {
     }
 
@@ -37,6 +48,11 @@ public class FinancialConsultant {
         String profileUrl,
         String introduceMessage
     ) {
+        Assert.hasLength(phoneNumber, "phoneNumber는 null이거나 빈값일 수 없습니다.");
+        Assert.hasLength(name, "name는 null이거나 빈값일 수 없습니다.");
+        Assert.hasLength(profileUrl, "profileUrl는 null이거나 빈값일 수 없습니다.");
+        Assert.hasLength(introduceMessage, "introduceMessage는 null이거나 빈값일 수 없습니다.");
+
         this.phoneNumber = phoneNumber;
         this.name = name;
         this.profileUrl = profileUrl;
@@ -58,6 +74,53 @@ public class FinancialConsultant {
         );
     }
 
+    private FinancialConsultant(
+        String employeeNumber,
+        String consultantPassword,
+        String salt,
+        String phoneNumber,
+        String name,
+        String profileUrl,
+        String introduceMessage
+    ) {
+        Assert.hasLength(employeeNumber, "employeeNumber는 null이거나 빈값일 수 없습니다.");
+        Assert.hasLength(consultantPassword, "consultantPassword는 null이거나 빈값일 수 없습니다.");
+        Assert.hasLength(salt, "salt는 null이거나 빈값일 수 없습니다.");
+        Assert.hasLength(phoneNumber, "phoneNumber는 null이거나 빈값일 수 없습니다.");
+        Assert.hasLength(name, "name는 null이거나 빈값일 수 없습니다.");
+        Assert.hasLength(profileUrl, "profileUrl는 null이거나 빈값일 수 없습니다.");
+        Assert.hasLength(introduceMessage, "introduceMessage는 null이거나 빈값일 수 없습니다.");
+
+        this.employeeNumber = employeeNumber;
+        this.consultantPassword = consultantPassword;
+        this.salt = salt;
+        this.phoneNumber = phoneNumber;
+        this.name = name;
+        this.profileUrl = profileUrl;
+        this.introduceMessage = introduceMessage;
+        this.consultationState = ConsultationState.AVAILABLE.name();
+    }
+
+    public static FinancialConsultant of(
+        String employeeNumber,
+        String consultantPassword,
+        String salt,
+        String phoneNumber,
+        String name,
+        String profileUrl,
+        String introduceMessage
+    ) {
+        return new FinancialConsultant(
+            employeeNumber,
+            consultantPassword,
+            salt,
+            phoneNumber,
+            name,
+            profileUrl,
+            introduceMessage
+        );
+    }
+
     public void startConsulting() {
         this.consultationState = ConsultationState.UNAVAILABLE.name();
     }
@@ -66,4 +129,11 @@ public class FinancialConsultant {
         this.consultationState = ConsultationState.AVAILABLE.name();
     }
 
+    public void changePassword(String consultantPassword) {
+        this.consultantPassword = consultantPassword;
+    }
+
+    public void changeSalt(String salt) {
+        this.salt = salt;
+    }
 }

--- a/src/main/java/com/hellomeritz/member/repository/fc/FinancialConsultantJapRepository.java
+++ b/src/main/java/com/hellomeritz/member/repository/fc/FinancialConsultantJapRepository.java
@@ -5,13 +5,17 @@ import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FinancialConsultantJapRepository extends JpaRepository<FinancialConsultant, Long> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select fc from FinancialConsultant as fc where fc.consultationState = 'AVAILABLE'")
     List<FinancialConsultant> findFinancialConsultant();
+
+    Optional<FinancialConsultant> findByEmployeeNumber (String employeeNumber);
 
 }

--- a/src/main/java/com/hellomeritz/member/repository/fc/FinancialConsultantRepository.java
+++ b/src/main/java/com/hellomeritz/member/repository/fc/FinancialConsultantRepository.java
@@ -14,4 +14,6 @@ public interface FinancialConsultantRepository {
 
     List<FinancialConsultant> getFinancialConsultantWithAvailable();
 
+    FinancialConsultant getByEmployeeNumber (String employeeNumber);
+
 }

--- a/src/main/java/com/hellomeritz/member/repository/fc/FinancialConsultantRepositoryImpl.java
+++ b/src/main/java/com/hellomeritz/member/repository/fc/FinancialConsultantRepositoryImpl.java
@@ -34,4 +34,10 @@ public class FinancialConsultantRepositoryImpl implements FinancialConsultantRep
         return financialConsultants;
     }
 
+    @Override
+    public FinancialConsultant getByEmployeeNumber(String employeeNumber) {
+        return financialConsultantJapRepository.findByEmployeeNumber(employeeNumber)
+            .orElseThrow(()-> new EntityNotFoundException("해당하는 설계사는 존재하지 않습니다."));
+    }
+
 }

--- a/src/main/java/com/hellomeritz/member/service/MemberService.java
+++ b/src/main/java/com/hellomeritz/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.hellomeritz.member.service;
 
+import com.hellomeritz.global.cache.CacheType;
 import com.hellomeritz.member.domain.FinancialConsultant;
 import com.hellomeritz.member.domain.Foreigner;
 import com.hellomeritz.member.global.IpSensor;
@@ -10,6 +11,7 @@ import com.hellomeritz.member.repository.fc.FinancialConsultantRepository;
 import com.hellomeritz.member.repository.foreign.ForeignRepository;
 import com.hellomeritz.member.service.dto.param.*;
 import com.hellomeritz.member.service.dto.result.*;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -61,12 +63,14 @@ public class MemberService {
         smsManager.sendAlarmMessage(param.t0SmsSendRequest(financialConsultant.getPhoneNumber()));
     }
 
+    @Cacheable(cacheNames = "consultant", key = "#param.userId()")
     public FcInfoResult getFinancialConsultantInfo(FinancialConsultantInfoGetParam param) {
         FinancialConsultant financialConsultant
             = financialConsultantRepository.getFinancialConsultant(param.userId());
         return FcInfoResult.of(financialConsultant);
     }
 
+    @Cacheable(cacheNames = "foreigner", key = "#param.userId()")
     public ForeignerInfoResult getForeignerInfo(ForeignerInfoGetParam param) {
         Foreigner foreigner = foreignRepository.getById(param.userId());
         return ForeignerInfoResult.of(foreigner);

--- a/src/main/java/com/hellomeritz/member/service/MemberService.java
+++ b/src/main/java/com/hellomeritz/member/service/MemberService.java
@@ -81,4 +81,11 @@ public class MemberService {
         int randomIndex = random.nextInt(consultants.size());
         return consultants.get(randomIndex);
     }
+
+    @Transactional
+    public void endConsultation(FinancialConsultantChangeStateParam param) {
+        FinancialConsultant financialConsultant = financialConsultantRepository.getFinancialConsultant(param.fcId());
+        financialConsultant.endConsulting();
+    }
+
 }

--- a/src/main/java/com/hellomeritz/member/service/dto/param/ConsultantLoginParam.java
+++ b/src/main/java/com/hellomeritz/member/service/dto/param/ConsultantLoginParam.java
@@ -1,0 +1,29 @@
+package com.hellomeritz.member.service.dto.param;
+
+import com.hellomeritz.member.domain.FinancialConsultant;
+import com.hellomeritz.global.encryption.dto.EncryptionRequest;
+import com.hellomeritz.global.encryption.dto.PasswordMatchRequest;
+
+import java.time.LocalDateTime;
+
+public record ConsultantLoginParam(
+    String employeeNumber,
+    String consultantPassword
+) {
+    public PasswordMatchRequest toPasswordMatchRequest(FinancialConsultant financialConsultant) {
+        return new PasswordMatchRequest(
+            consultantPassword.toCharArray(),
+            financialConsultant.getConsultantPassword(),
+            financialConsultant.getSalt()
+        );
+    }
+
+    public EncryptionRequest toEncryptionRequest(String clientIp) {
+        return new EncryptionRequest(
+            consultantPassword,
+            clientIp,
+            LocalDateTime.now()
+        );
+    }
+
+}

--- a/src/main/java/com/hellomeritz/member/service/dto/param/ConsultantSignUpParam.java
+++ b/src/main/java/com/hellomeritz/member/service/dto/param/ConsultantSignUpParam.java
@@ -1,0 +1,37 @@
+package com.hellomeritz.member.service.dto.param;
+
+import com.hellomeritz.global.encryption.PassWord;
+import com.hellomeritz.member.domain.FinancialConsultant;
+import com.hellomeritz.global.encryption.dto.EncryptionRequest;
+import com.hellomeritz.global.encryption.dto.EncryptionResponse;
+
+import java.time.LocalDateTime;
+
+public record ConsultantSignUpParam(
+    String employeeNumber,
+    PassWord consultantPassword,
+    String phoneNumber,
+    String name,
+    String profileUrl,
+    String introduceMessage
+) {
+    public FinancialConsultant toFinancialConsultant(EncryptionResponse response) {
+        return FinancialConsultant.of(
+            employeeNumber,
+            response.password(),
+            response.salt(),
+            phoneNumber,
+            name,
+            profileUrl,
+            introduceMessage
+        );
+    }
+
+    public EncryptionRequest toEncryptionRequest(String clientIp) {
+        return new EncryptionRequest(
+            consultantPassword.getPassword(),
+            clientIp,
+            LocalDateTime.now()
+        );
+    }
+}

--- a/src/main/java/com/hellomeritz/member/service/dto/param/FinancialConsultantChangeStateParam.java
+++ b/src/main/java/com/hellomeritz/member/service/dto/param/FinancialConsultantChangeStateParam.java
@@ -1,0 +1,11 @@
+package com.hellomeritz.member.service.dto.param;
+
+public record FinancialConsultantChangeStateParam(
+    long fcId
+) {
+    public static FinancialConsultantChangeStateParam to(
+        Long fcId
+    ) {
+        return new FinancialConsultantChangeStateParam(fcId);
+    }
+}

--- a/src/main/java/com/hellomeritz/member/service/dto/result/ConsultantLoginResult.java
+++ b/src/main/java/com/hellomeritz/member/service/dto/result/ConsultantLoginResult.java
@@ -1,0 +1,16 @@
+package com.hellomeritz.member.service.dto.result;
+
+public record ConsultantLoginResult(
+    boolean isMyConsultant,
+    long fcId
+) {
+    public static ConsultantLoginResult to(
+        Boolean isMyConsultant,
+        Long fcId
+    ){
+        return new ConsultantLoginResult(
+            isMyConsultant,
+            fcId
+        );
+    }
+}

--- a/src/main/java/com/hellomeritz/member/service/dto/result/ConsultantSignUpResult.java
+++ b/src/main/java/com/hellomeritz/member/service/dto/result/ConsultantSignUpResult.java
@@ -1,0 +1,9 @@
+package com.hellomeritz.member.service.dto.result;
+
+public record ConsultantSignUpResult(
+    Long fcId
+) {
+    public static ConsultantSignUpResult to(Long fcId) {
+        return new ConsultantSignUpResult(fcId);
+    }
+}

--- a/src/main/resources/static/docs/chats.html
+++ b/src/main/resources/static/docs/chats.html
@@ -758,7 +758,7 @@ Content-Length: 129
 
 {
   "textBySpeech" : "Hello my name is byeol",
-  "createdAt" : "2024-05-13T12:03:49.480445200",
+  "createdAt" : "2024-05-13T12:50:01.507708700",
   "sttProvider" : "WHISPER"
 }</code></pre>
 </div>

--- a/src/main/resources/static/docs/chats.html
+++ b/src/main/resources/static/docs/chats.html
@@ -758,7 +758,7 @@ Content-Length: 129
 
 {
   "textBySpeech" : "Hello my name is byeol",
-  "createdAt" : "2024-05-12T20:06:47.074224800",
+  "createdAt" : "2024-05-13T12:03:49.480445200",
   "sttProvider" : "WHISPER"
 }</code></pre>
 </div>

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -891,7 +891,7 @@ Content-Length: 129
 
 {
   "textBySpeech" : "Hello my name is byeol",
-  "createdAt" : "2024-05-13T12:03:49.480445200",
+  "createdAt" : "2024-05-13T12:50:01.507708700",
   "sttProvider" : "WHISPER"
 }</code></pre>
 </div>

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -551,6 +551,24 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_response_success_17">Response (Success)</a></li>
 </ul>
 </li>
+<li><a href="#_상담원_상담_가능_상태로_바꿔주는_api">상담원 상담 가능 상태로 바꿔주는 API</a>
+<ul class="sectlevel2">
+<li><a href="#_request_18">Request</a></li>
+<li><a href="#_response_success_18">Response (Success)</a></li>
+</ul>
+</li>
+<li><a href="#_상담원_회원가입_api">상담원 회원가입 API</a>
+<ul class="sectlevel2">
+<li><a href="#_request_19">Request</a></li>
+<li><a href="#_response_success_19">Response (Success)</a></li>
+</ul>
+</li>
+<li><a href="#_상담원_로그인_api">상담원 로그인 API</a>
+<ul class="sectlevel2">
+<li><a href="#_request_20">Request</a></li>
+<li><a href="#_response_success_20">Response (Success)</a></li>
+</ul>
+</li>
 </ul>
 </div>
 </div>
@@ -873,7 +891,7 @@ Content-Length: 129
 
 {
   "textBySpeech" : "Hello my name is byeol",
-  "createdAt" : "2024-05-12T20:06:47.074224800",
+  "createdAt" : "2024-05-13T12:03:49.480445200",
   "sttProvider" : "WHISPER"
 }</code></pre>
 </div>
@@ -1918,6 +1936,253 @@ Content-Length: 18
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>fcId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">상담 가능한 상담원의 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_상담원_상담_가능_상태로_바꿔주는_api"><a class="link" href="#_상담원_상담_가능_상태로_바꿔주는_api">상담원 상담 가능 상태로 바꿔주는 API</a></h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>상담이 끝나면 상담원의 상담 가능 상태를
+UNAVAILABLE에서 AVAILABLE로 바꿔줍니다.</p>
+</div>
+<div class="sect2">
+<h3 id="_request_18"><a class="link" href="#_request_18">Request</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /consultants/1 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 11. /consultants/{fcId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>fcId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상담원의 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_response_success_18"><a class="link" href="#_response_success_18">Response (Success)</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_상담원_회원가입_api"><a class="link" href="#_상담원_회원가입_api">상담원 회원가입 API</a></h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>상담원 회원가입 API
+사원 번호는 미리 받은 상태입니다.</p>
+</div>
+<div class="sect2">
+<h3 id="_request_19"><a class="link" href="#_request_19">Request</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /consultants HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 251
+Host: localhost:8080
+
+{
+  "employeeNumber" : "123401343",
+  "consultantPassword" : "123456789TWE!@",
+  "phoneNumber" : "01012345678",
+  "name" : "KIM BYEOL",
+  "profileUrl" : "https://gcp//meritz-profile/mypicture",
+  "introduceMessage" : "hello, my name is byeol"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>employeeNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">설계사 사원번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>consultantPassword</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">설계사 비밀번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>phoneNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">설계사 전화번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>profileUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">프로필 url</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>introduceMessage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">소개 메세지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_response_success_19"><a class="link" href="#_response_success_19">Response (Success)</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
+Content-Type: application/json;charset=UTF-8
+Content-Length: 18
+
+{
+  "fcId" : 1
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>fcId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 가입된 상담원의 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_상담원_로그인_api"><a class="link" href="#_상담원_로그인_api">상담원 로그인 API</a></h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>상담원 로그인 API</p>
+</div>
+<div class="sect2">
+<h3 id="_request_20"><a class="link" href="#_request_20">Request</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /consultants/passwords HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 81
+Host: localhost:8080
+
+{
+  "consultantPassword" : "123401343",
+  "employeeNumber" : "12345678TWE!@"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>employeeNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">설계사 사원번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>consultantPassword</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">설계사 비밀번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_response_success_20"><a class="link" href="#_response_success_20">Response (Success)</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 46
+
+{
+  "isMyConsultant" : true,
+  "fcId" : 1
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>isMyConsultant</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">로그인한 사람이 우리 상담원인가?</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>fcId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">설계사 ID</p></td>
 </tr>
 </tbody>
 </table>

--- a/src/main/resources/static/docs/members.html
+++ b/src/main/resources/static/docs/members.html
@@ -962,11 +962,258 @@ Content-Length: 18
 </div>
 </div>
 </div>
+<div class="sect1">
+<h2 id="_상담원_상담_가능_상태로_바꿔주는_api">상담원 상담 가능 상태로 바꿔주는 API</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>상담이 끝나면 상담원의 상담 가능 상태를
+UNAVAILABLE에서 AVAILABLE로 바꿔줍니다.</p>
+</div>
+<div class="sect2">
+<h3 id="_request_8">Request</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /consultants/1 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 5. /consultants/{fcId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>fcId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상담원의 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_response_success_8">Response (Success)</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_상담원_회원가입_api">상담원 회원가입 API</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>상담원 회원가입 API
+사원 번호는 미리 받은 상태입니다.</p>
+</div>
+<div class="sect2">
+<h3 id="_request_9">Request</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /consultants HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 251
+Host: localhost:8080
+
+{
+  "employeeNumber" : "123401343",
+  "consultantPassword" : "123456789TWE!@",
+  "phoneNumber" : "01012345678",
+  "name" : "KIM BYEOL",
+  "profileUrl" : "https://gcp//meritz-profile/mypicture",
+  "introduceMessage" : "hello, my name is byeol"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>employeeNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">설계사 사원번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>consultantPassword</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">설계사 비밀번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>phoneNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">설계사 전화번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>profileUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">프로필 url</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>introduceMessage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">소개 메세지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_response_success_9">Response (Success)</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 201 Created
+Content-Type: application/json;charset=UTF-8
+Content-Length: 18
+
+{
+  "fcId" : 1
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>fcId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 가입된 상담원의 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_상담원_로그인_api">상담원 로그인 API</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>상담원 로그인 API</p>
+</div>
+<div class="sect2">
+<h3 id="_request_10">Request</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PATCH /consultants/passwords HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 81
+Host: localhost:8080
+
+{
+  "consultantPassword" : "123401343",
+  "employeeNumber" : "12345678TWE!@"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>employeeNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">설계사 사원번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>consultantPassword</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">설계사 비밀번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_response_success_10">Response (Success)</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 46
+
+{
+  "isMyConsultant" : true,
+  "fcId" : 1
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>isMyConsultant</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">로그인한 사람이 우리 상담원인가?</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>fcId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">설계사 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-05-12 19:06:11 +0900
+Last updated 2024-05-13 11:35:19 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/js/consultant-chat.js
+++ b/src/main/resources/static/js/consultant-chat.js
@@ -248,3 +248,39 @@ async function leaveChatRoom() {
         throw error;
     }
 }
+
+function completeConsultation() {
+        var url = `/consultants/${consultantId}`;
+
+           // PUT 요청 보내기
+           fetch(url, {
+               method: 'PUT',
+               headers: {
+                   'Content-Type': 'application/json'
+               },
+               body: JSON.stringify({})
+           })
+           .then(response => {
+               endMessages();
+           })
+           .catch(error => {
+               console.error('Error:', error);
+               alert('상담 완료 요청을 처리하는 동안 오류가 발생했습니다. 다시 시도해주세요.');
+           });
+}
+
+function endMessages() {
+     const messageList = document.getElementById('message-list');
+
+     const originMessageElement = document.createElement('div');
+     originMessageElement.className = 'message sent';
+
+     const originContentElement = document.createElement('div');
+     originContentElement.className = 'message-content';
+     originContentElement.textContent = '상담이 완료되었습니다.✅ 다른 궁금한 사항이 있다면 언제든 다시 물아봐주세요';
+
+     originMessageElement.appendChild(originContentElement);
+
+     messageList.appendChild(originMessageElement);
+
+}

--- a/src/main/resources/static/js/consultant-chatrooms.js
+++ b/src/main/resources/static/js/consultant-chatrooms.js
@@ -1,8 +1,16 @@
 let userId = 1;
 
+function getUserIdFromUrl() {
+    var queryString = window.location.search;
+    var urlParams = new URLSearchParams(queryString);
+    return urlParams.get('fcId');
+}
+
+
 document.addEventListener("DOMContentLoaded", function() {
     getChatRooms();
     getConsultantInfo();
+    userId = getUserIdFromUrl();
 });
 
 async function getChatRooms() {

--- a/src/main/resources/static/js/consultant-login.js
+++ b/src/main/resources/static/js/consultant-login.js
@@ -1,0 +1,33 @@
+document.getElementById('loginForm').addEventListener('submit', function(event) {
+    event.preventDefault();
+
+    var employeeNumber = document.getElementById('employeeNumber').value;
+    var password = document.getElementById('password').value;
+
+    var url = '/consultants/passwords';
+    var requestBody = {
+        employeeNumber: employeeNumber,
+        consultantPassword : password
+    };
+
+    fetch(url, {
+        method: 'PATCH',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(requestBody)
+    })
+    .then(response => response.json())
+    .then(data => {
+         if (data.isMyConsultant === true) {
+                    window.location.href = `/templates/consultant-chatrooms.html?fcId=${data.fcId}`;
+         } else {
+              // 로그인 실패 알림창 띄우기
+              alert('로그인에 실패했습니다. 사용자 이름과 비밀번호를 확인해주세요.');
+          }
+    })
+    .catch(error => {
+        console.error('Error:', error);
+        alert('로그인에 실패했습니다. 사용자 이름과 비밀번호를 확인해주세요.');
+    });
+});

--- a/src/main/resources/static/styles/chat.css
+++ b/src/main/resources/static/styles/chat.css
@@ -253,3 +253,20 @@ button[onclick="sendMessage()"]:hover {
 #submitPassword:hover {
     background-color: #45a049;
 }
+
+/*상담완료 버튼*/
+.complete-button {
+    width: calc(100% - 20px);
+    margin: 10px;
+    padding: 10px;
+    background-color: #ff6347; /* 버튼 배경색 */
+    color: white; /* 버튼 텍스트 색상 */
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: background-color 0.3s;
+}
+
+.complete-button:hover {
+    background-color: #d6342b; /* 마우스 호버 시 배경색 */
+}

--- a/src/main/resources/static/styles/consultant-login.css
+++ b/src/main/resources/static/styles/consultant-login.css
@@ -1,0 +1,56 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f4f4f4;
+    margin: 0;
+    padding: 0;
+}
+
+.container {
+    max-width: 400px;
+    margin: 100px auto;
+    padding: 20px;
+    background-color: #fff;
+    border-radius: 5px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+form {
+    text-align: center;
+}
+
+input[type="text"],
+input[type="password"] {
+    width: 100%;
+    padding: 10px;
+    margin: 8px 0;
+    box-sizing: border-box;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+button {
+    width: 100%;
+    background-color: #4caf50;
+    color: white;
+    padding: 14px 20px;
+    margin: 8px 0;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 16px;
+}
+
+button:hover {
+    background-color: #45a049;
+}
+
+.input-group {
+    margin-bottom: 16px;
+    text-align: left;
+}
+
+.input-group label {
+    display: block;
+    margin-bottom: 6px;
+    font-weight: bold;
+}

--- a/src/main/resources/static/templates/consultant-login.html
+++ b/src/main/resources/static/templates/consultant-login.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>상담원 로그인</title>
+    <link rel="stylesheet" href="/styles/consultant-login.css">
+</head>
+<body>
+<div class="container">
+    <form id="loginForm">
+        <h2>상담원 로그인</h2>
+        <div class="input-group">
+            <label for="employeeNumber">사원번호:</label>
+            <input type="text" id="employeeNumber" name="employeeNumber" value="19970121" required>
+        </div>
+        <div class="input-group">
+            <label for="password">비밀번호:</label>
+            <input type="password" id="password" name="password" value="123456789QUF!" required>
+        </div>
+        <button type="submit">로그인</button>
+    </form>
+</div>
+
+<script src="/js/consultant-login.js"></script>
+</body>
+</html>

--- a/src/main/resources/static/templates/consultant.html
+++ b/src/main/resources/static/templates/consultant.html
@@ -36,7 +36,10 @@
     <div id="message-list"></div>
     <textarea id="message-input" class="message-input" placeholder="Type a message... (Shift+Enter for new line)" rows="4"></textarea>
     <button onclick="sendMessage()">Send</button>
+
+    <button class="complete-button" onclick="completeConsultation()">상담 완료🆗 <br> 다른 외국인 고객을 만나보아요 </button>
 </div>
+
 
 <script src="/js/consultant-chat.js"></script>
 </body>

--- a/src/test/java/com/hellomeritz/global/ChatFixture.java
+++ b/src/test/java/com/hellomeritz/global/ChatFixture.java
@@ -5,7 +5,7 @@ import com.hellomeritz.chat.controller.dto.response.ChatRoomUserInfoResponse;
 import com.hellomeritz.chat.domain.ChatMessage;
 import com.hellomeritz.chat.domain.ChatMessageType;
 import com.hellomeritz.chat.domain.ChatRoom;
-import com.hellomeritz.chat.domain.ChatRoomPassword;
+import com.hellomeritz.global.encryption.PassWord;
 import com.hellomeritz.chat.global.SourceLanguage;
 import com.hellomeritz.chat.global.TargetLanguage;
 import com.hellomeritz.chat.global.stt.SttProvider;
@@ -250,7 +250,7 @@ public class ChatFixture {
         long chatRoomId
     ) {
         return new ChatRoomPasswordCreateParam(
-            ChatRoomPassword.of("30303TWSA!!!"),
+            PassWord.of("30303TWSA!!!"),
             chatRoomId,
             LocalDateTime.now()
         );

--- a/src/test/java/com/hellomeritz/global/FinancialConsultantFixture.java
+++ b/src/test/java/com/hellomeritz/global/FinancialConsultantFixture.java
@@ -1,7 +1,11 @@
 package com.hellomeritz.global;
 
+import com.hellomeritz.member.controller.dto.request.ConsultantLoginRequest;
+import com.hellomeritz.member.controller.dto.request.ConsultantSignUpRequest;
 import com.hellomeritz.member.domain.FinancialConsultant;
+import com.hellomeritz.member.service.dto.result.ConsultantLoginResult;
 import com.hellomeritz.member.service.dto.result.ConsultantMatchResult;
+import com.hellomeritz.member.service.dto.result.ConsultantSignUpResult;
 import com.hellomeritz.member.service.dto.result.FcInfoResult;
 
 public class FinancialConsultantFixture {
@@ -20,7 +24,7 @@ public class FinancialConsultantFixture {
     }
 
     public static FinancialConsultant financialConsultantNotVailable() {
-        FinancialConsultant financialConsultant =  FinancialConsultant.of(
+        FinancialConsultant financialConsultant = FinancialConsultant.of(
             "010-1234-6789",
             "박지호",
             "https://gcp//meritz-profile/mypicture",
@@ -44,4 +48,29 @@ public class FinancialConsultantFixture {
     public static ConsultantMatchResult consultantMatchResult() {
         return new ConsultantMatchResult(1L);
     }
+
+    public static ConsultantSignUpResult consultantSignUpResult() {
+        return new ConsultantSignUpResult(1L);
+    }
+
+    public static ConsultantSignUpRequest consultantSignUpRequest() {
+        return new ConsultantSignUpRequest(
+            "123401343",
+            "123456789TWE!@",
+            "01012345678",
+            "KIM BYEOL",
+            "https://gcp//meritz-profile/mypicture",
+            "hello, my name is byeol");
+    }
+
+    public static ConsultantLoginResult consultantLoginResult() {
+        return new ConsultantLoginResult(true, 1L);
+    }
+
+    public static ConsultantLoginRequest consultantLoginRequest() {
+        return new ConsultantLoginRequest(
+            "123401343",
+            "12345678TWE!@");
+    }
+
 }

--- a/src/test/java/com/hellomeritz/member/controller/ConsultantControllerDocsTest.java
+++ b/src/test/java/com/hellomeritz/member/controller/ConsultantControllerDocsTest.java
@@ -4,7 +4,9 @@ import com.hellomeritz.global.FinancialConsultantFixture;
 import com.hellomeritz.global.ForeignFixture;
 import com.hellomeritz.global.RestDocsSupport;
 import com.hellomeritz.member.service.MemberService;
+import com.hellomeritz.member.service.dto.result.ConsultantLoginResult;
 import com.hellomeritz.member.service.dto.result.ConsultantMatchResult;
+import com.hellomeritz.member.service.dto.result.ConsultantSignUpResult;
 import com.hellomeritz.member.service.dto.result.UserCheckIsFcResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,10 +19,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -29,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class ConsultantControllerDocsTest extends RestDocsSupport {
 
     MemberService memberService = mock(MemberService.class);
+
     @Override
     protected Object initController() {
         return new ConsultantController(memberService);
@@ -55,7 +56,7 @@ class ConsultantControllerDocsTest extends RestDocsSupport {
     @DisplayName("상담이 끝나면 상담원의 상태를 가능 상태로 변경하는 API")
     @Test
     void endConsultation() throws Exception {
-        mockMvc.perform(put("/consultants/{fcId}",1L)
+        mockMvc.perform(put("/consultants/{fcId}", 1L)
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding(StandardCharsets.UTF_8))
             .andDo(print())
@@ -63,6 +64,58 @@ class ConsultantControllerDocsTest extends RestDocsSupport {
             .andDo(document("end-consultation-and-change-available",
                 pathParameters(
                     parameterWithName("fcId").description("상담원의 ID")
+                )
+            ));
+    }
+
+    @DisplayName("상담원 회원가입 API")
+    @Test
+    void signUp() throws Exception {
+        ConsultantSignUpResult result = FinancialConsultantFixture.consultantSignUpResult();
+        given(memberService.signUp(any())).willReturn(result);
+
+        mockMvc.perform(post("/consultants")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(FinancialConsultantFixture.consultantSignUpRequest())))
+            .andDo(print())
+            .andExpect(status().isCreated())
+            .andDo(document("sign-up-consultant",
+                requestFields(
+                    fieldWithPath("employeeNumber").type(JsonFieldType.STRING).description("설계사 사원번호"),
+                    fieldWithPath("consultantPassword").type(JsonFieldType.STRING).description("설계사 비밀번호"),
+                    fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("설계사 전화번호"),
+                    fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
+                    fieldWithPath("profileUrl").type(JsonFieldType.STRING).description("프로필 url"),
+                    fieldWithPath("introduceMessage").type(JsonFieldType.STRING).description("소개 메세지")
+
+                ),
+                responseFields(
+                    fieldWithPath("fcId").type(JsonFieldType.NUMBER).description("회원 가입된 상담원의 ID")
+                )
+            ));
+    }
+
+    @DisplayName("상담원 로그인 API")
+    @Test
+    void login() throws Exception {
+        ConsultantLoginResult result = FinancialConsultantFixture.consultantLoginResult();
+        given(memberService.login(any())).willReturn(result);
+
+        mockMvc.perform(patch("/consultants/passwords")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(FinancialConsultantFixture.consultantLoginRequest())))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andDo(document("login-consultant",
+                requestFields(
+                    fieldWithPath("employeeNumber").type(JsonFieldType.STRING).description("설계사 사원번호"),
+                    fieldWithPath("consultantPassword").type(JsonFieldType.STRING).description("설계사 비밀번호")
+                ),
+                responseFields(
+                    fieldWithPath("isMyConsultant").type(JsonFieldType.BOOLEAN).description("로그인한 사람이 우리 상담원인가?"),
+                    fieldWithPath("fcId").type(JsonFieldType.NUMBER).description("설계사 ID")
                 )
             ));
     }

--- a/src/test/java/com/hellomeritz/member/controller/ConsultantControllerDocsTest.java
+++ b/src/test/java/com/hellomeritz/member/controller/ConsultantControllerDocsTest.java
@@ -18,8 +18,11 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -48,4 +51,20 @@ class ConsultantControllerDocsTest extends RestDocsSupport {
                 )
             ));
     }
+
+    @DisplayName("상담이 끝나면 상담원의 상태를 가능 상태로 변경하는 API")
+    @Test
+    void endConsultation() throws Exception {
+        mockMvc.perform(put("/consultants/{fcId}",1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding(StandardCharsets.UTF_8))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andDo(document("end-consultation-and-change-available",
+                pathParameters(
+                    parameterWithName("fcId").description("상담원의 ID")
+                )
+            ));
+    }
+
 }

--- a/src/test/java/com/hellomeritz/member/service/MemberServiceTest.java
+++ b/src/test/java/com/hellomeritz/member/service/MemberServiceTest.java
@@ -106,7 +106,6 @@ class MemberServiceTest {
 
         // then
         assertThat(changedFinancialConsultant.getConsultationState()).isEqualTo(ConsultationState.AVAILABLE.name());
-
-
     }
+
 }

--- a/src/test/java/com/hellomeritz/member/service/MemberServiceTest.java
+++ b/src/test/java/com/hellomeritz/member/service/MemberServiceTest.java
@@ -2,16 +2,17 @@ package com.hellomeritz.member.service;
 
 import com.hellomeritz.global.FinancialConsultantFixture;
 import com.hellomeritz.global.ForeignFixture;
+import com.hellomeritz.member.domain.ConsultationState;
 import com.hellomeritz.member.domain.FinancialConsultant;
 import com.hellomeritz.member.domain.Foreigner;
 import com.hellomeritz.member.repository.fc.FinancialConsultantRepository;
 import com.hellomeritz.member.repository.foreign.ForeignRepository;
+import com.hellomeritz.member.service.dto.param.FinancialConsultantChangeStateParam;
 import com.hellomeritz.member.service.dto.param.FinancialConsultantInfoGetParam;
 import com.hellomeritz.member.service.dto.param.ForeignerInfoGetParam;
 import com.hellomeritz.member.service.dto.result.ConsultantMatchResult;
 import com.hellomeritz.member.service.dto.result.FcInfoResult;
 import com.hellomeritz.member.service.dto.result.ForeignerInfoResult;
-import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -91,5 +92,21 @@ class MemberServiceTest {
         assertThrows(RuntimeException.class
             , ()->memberService.matchConsultant()
         );
+    }
+
+    @DisplayName("상담원은 상담이 끝나면 본인의 상태를 UNAVAILABLE로 바꿀 수 있다.")
+    @Test
+    void changeConsultationState() {
+        // given
+        FinancialConsultant financialConsultant = financialConsultantRepository.save(FinancialConsultantFixture.financialConsultantNotVailable());
+
+        // when
+        memberService.endConsultation(new FinancialConsultantChangeStateParam(financialConsultant.getFinancialConsultantId()));
+        FinancialConsultant changedFinancialConsultant = financialConsultantRepository.getFinancialConsultant(financialConsultant.getFinancialConsultantId());
+
+        // then
+        assertThat(changedFinancialConsultant.getConsultationState()).isEqualTo(ConsultationState.AVAILABLE.name());
+
+
     }
 }


### PR DESCRIPTION
## 구현 내용
- 상담원 회원가입, 로그인, 상담 완료 구현 및 Etag와 로컬 캐시 적용

## 상세 내용
- 상담원 회원가입 및 로그인 api 구현 및 페이지 연결
- 상담원 정보와 외국인 정보는 잘 바뀌지 않는 정보인데 새로 고침할 때마다 쿼리가 새롭게 나가는 것을 확인하고 로컬 캐시를 적용하였으며 바뀌지 않은 데이터에 대한 페이로드를 줄이기 위해서 Etag를 적용
  - 로컬 캐시로는 다른 캐시에 성능이 좋은 Caffeine을 사용하였습니다.
- 또한 정적 자원에 대한 브라우저 캐시나 메모리에 적용하기 위해서 WebConfig 설정을 추가하였습니다.
- 상담이 완료되면 본인의 상태를 UNAVAILABLE에서 AVAILABLE로 바꾸기 위한 버튼을 추가하였습니다,